### PR TITLE
Use orchestrated docker image override in contract tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,18 +24,33 @@ on:
         type: string
 
 jobs:
-  prepare-enterprise-artifact:
-    if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+  # Internal-only prep for Specmatic orchestrator runs.
+  prepare_specmatic_internal_assets:
+    if: ${{ inputs.orchestrator_run_suffix != '' || (inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare Specmatic Enterprise artifact
+      - name: Add orchestrator context to summary
+        if: ${{ inputs.orchestrator_run_suffix != '' }}
+        run: |
+          echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
+          echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up JDK 17
+        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Prepare Specmatic Enterprise jar
+        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
         shell: bash
         run: |
           set -euo pipefail
 
           mkdir -p "$HOME/.specmatic"
           url="${{ inputs.enterprise_artifact_url }}"
-          output_path="$HOME/.specmatic/specmatic-enterprise.jar"
+          output_path="$RUNNER_TEMP/specmatic-enterprise.jar"
           echo "Downloading Enterprise artifact from:"
           echo "$url"
 
@@ -47,17 +62,42 @@ jobs:
           curl --http1.1 -L --fail --continue-at - "$url" -o "$output_path"
           echo "Enterprise artifact downloaded successfully"
 
-      - name: Upload Specmatic Enterprise artifact
+      - name: Upload Specmatic Enterprise jar
+        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
         uses: actions/upload-artifact@v6
         with:
           name: specmatic-enterprise-jar
-          path: ~/.specmatic/specmatic-enterprise.jar
+          path: ${{ runner.temp }}/specmatic-enterprise.jar
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Docker Login for orchestrator snapshot image
+        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
+
+      - name: Prepare snapshot image tarball for orchestrator run
+        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          image_archive="$RUNNER_TEMP/specmatic-enterprise-image.tar"
+          docker pull specmatic/enterprise-snapshot
+          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+          docker image save specmatic/enterprise-snapshot specmatic/enterprise:latest -o "$image_archive"
+
+      - name: Upload snapshot image tarball
+        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: specmatic-enterprise-image
+          path: ${{ runner.temp }}/specmatic-enterprise-image.tar
           if-no-files-found: error
           retention-days: 1
 
   buildAndTest:
-    needs: [prepare-enterprise-artifact]
-    if: ${{ always() && (needs.prepare-enterprise-artifact.result == 'success' || needs.prepare-enterprise-artifact.result == 'skipped') }}
+    needs: [prepare_specmatic_internal_assets]
+    if: ${{ always() && (needs.prepare_specmatic_internal_assets.result == 'success' || needs.prepare_specmatic_internal_assets.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -80,12 +120,6 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v6
 
-      - name: Add orchestrator context to summary
-        if: ${{ inputs.orchestrator_run_suffix != '' }}
-        run: |
-          echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
-          echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -98,12 +132,35 @@ jobs:
           mkdir -p ~/.specmatic
           echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
 
-      - name: Download Specmatic Enterprise Jar artifact
+      - name: Download prepared Specmatic Enterprise jar
         if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
         uses: actions/download-artifact@v5
         with:
           name: specmatic-enterprise-jar
-          path: ~/.specmatic
+          path: ${{ runner.temp }}/specmatic-jar
+
+      - name: Place prepared Specmatic Enterprise jar
+        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$HOME/.specmatic"
+          cp "$RUNNER_TEMP/specmatic-jar/specmatic-enterprise.jar" "$HOME/.specmatic/specmatic-enterprise.jar"
+
+      - name: Install prepared Specmatic Enterprise jar into local Maven
+        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mvn install:install-file \
+            -Dfile="$HOME/.specmatic/specmatic-enterprise.jar" \
+            -DgroupId=io.specmatic.enterprise \
+            -DartifactId=executable \
+            -Dversion="${ENTERPRISE_VERSION}" \
+            -Dpackaging=jar \
+            -DgeneratePom=true
 
       - name: Download Specmatic Enterprise Jar
         if: ${{ matrix.needsCliInstall }}
@@ -121,37 +178,20 @@ jobs:
             echo "Installed default Enterprise jar"
           fi
 
-      - name: Docker Login for orchestrator snapshot run
+      - name: Download prepared snapshot image
         if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
+        uses: actions/download-artifact@v5
+        with:
+          name: specmatic-enterprise-image
+          path: ${{ runner.temp }}
 
-      - name: Pull and retag snapshot image for orchestrator run
+      - name: Load prepared snapshot image
         if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
         shell: bash
         run: |
           set -euo pipefail
 
-          docker pull specmatic/enterprise-snapshot
-          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
-
-      - name: Install Specmatic Enterprise Jar into local Maven
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ ! -f "$HOME/.specmatic/specmatic-enterprise.jar" ]; then
-            echo "Expected enterprise jar at $HOME/.specmatic/specmatic-enterprise.jar"
-            exit 1
-          fi
-
-          mvn install:install-file \
-            -Dfile="$HOME/.specmatic/specmatic-enterprise.jar" \
-            -DgroupId=io.specmatic.enterprise \
-            -DartifactId=executable \
-            -Dversion="${ENTERPRISE_VERSION}" \
-            -Dpackaging=jar \
-            -DgeneratePom=true
+          docker load -i "$RUNNER_TEMP/specmatic-enterprise-image.tar"
 
       - name: Run BFF Contract Test
         shell: bash
@@ -219,6 +259,59 @@ jobs:
         with:
           name: html-report-${{ matrix.name }}
           path: build/reports/specmatic/test/html
+
+  cleanup_specmatic_internal_assets:
+    if: ${{ always() && (inputs.orchestrator_run_suffix != '' || (inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '')) }}
+    needs:
+      - prepare_specmatic_internal_assets
+      - buildAndTest
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete prepared enterprise jar artifact
+        if: ${{ needs.prepare_specmatic_internal_assets.result == 'success' && inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            const target = artifacts.find((artifact) => artifact.name === 'specmatic-enterprise-jar');
+            if (target) {
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: target.id
+              });
+              core.info(`Deleted artifact ${target.name}`);
+            } else {
+              core.info('Artifact specmatic-enterprise-jar not found');
+            }
+
+      - name: Delete prepared enterprise image artifact
+        if: ${{ needs.prepare_specmatic_internal_assets.result == 'success' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            const target = artifacts.find((artifact) => artifact.name === 'specmatic-enterprise-image');
+            if (target) {
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: target.id
+              });
+              core.info(`Deleted artifact ${target.name}`);
+            } else {
+              core.info('Artifact specmatic-enterprise-image not found');
+            }
 
   docker:
     if: ${{ github.ref == 'refs/heads/main' && inputs.orchestrator_run_suffix == '' }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       enterprise_artifact_url:
-        description: Specmatic Enterprise jar/artifact URL under test
+        description: Deprecated fat-jar artifact URL input; retained for workflow compatibility
         required: false
         type: string
       orchestrator_run_suffix:
@@ -64,48 +64,21 @@ jobs:
           echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
           echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Prepare Specmatic Enterprise jar
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
+      - name: Install Gradle snapshot init script
+        if: ${{ inputs.orchestrator_run_suffix != '' && endsWith(inputs.enterprise_version, '-SNAPSHOT') }}
         shell: bash
         run: |
           set -euo pipefail
 
-          mkdir -p "$HOME/.specmatic"
-          url="${{ inputs.enterprise_artifact_url }}"
-          output_path="$HOME/.specmatic/specmatic-enterprise.jar"
-          echo "Downloading Enterprise artifact from:"
-          echo "$url"
-
-          initial_sleep=$(( RANDOM % 31 ))
-          echo "Initial jitter: ${initial_sleep}s"
-          sleep "$initial_sleep"
-
-          echo "Download attempt 1/1"
-          curl --http1.1 -L --fail --continue-at - "$url" -o "$output_path"
-          echo "Enterprise artifact downloaded successfully"
-
-      - name: Install prepared Specmatic Enterprise jar into local Maven
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        shell: bash
-        env:
-          ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
-        run: |
-          set -euo pipefail
-
-          mvn install:install-file \
-            -Dfile="$HOME/.specmatic/specmatic-enterprise.jar" \
-            -DgroupId=io.specmatic.enterprise \
-            -DartifactId=executable \
-            -Dversion="${ENTERPRISE_VERSION}" \
-            -Dpackaging=jar \
-            -DgeneratePom=true
+          mkdir -p "$HOME/.gradle/init.d"
+          cp ./gradle/specmatic-snapshots.init.gradle "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
 
       - name: Docker Login for orchestrator snapshot image
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && endsWith(inputs.enterprise_version, '-SNAPSHOT') }}
         run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
 
       - name: Prepare snapshot image for orchestrator run
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && endsWith(inputs.enterprise_version, '-SNAPSHOT') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -142,9 +115,7 @@ jobs:
 
           ./gradlew test \
             --tests="com.component.orders.contract.${{ matrix.testName }}" \
-            ${ENTERPRISE_VERSION:+-PspecmaticEnterpriseVersion=${ENTERPRISE_VERSION}} \
-            ${ENTERPRISE_VERSION:+-PenterpriseVersion=${ENTERPRISE_VERSION}}
-
+            ${ENTERPRISE_VERSION:+-PspecmaticEnterpriseVersion=${ENTERPRISE_VERSION}} 
 
       - name: Upload CTRF Report
         uses: actions/upload-artifact@v6

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,80 +24,7 @@ on:
         type: string
 
 jobs:
-  # Internal-only prep for Specmatic orchestrator runs.
-  prepare_specmatic_internal_assets:
-    if: ${{ inputs.orchestrator_run_suffix != '' || (inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add orchestrator context to summary
-        if: ${{ inputs.orchestrator_run_suffix != '' }}
-        run: |
-          echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
-          echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Set up JDK 17
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-
-      - name: Prepare Specmatic Enterprise jar
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mkdir -p "$HOME/.specmatic"
-          url="${{ inputs.enterprise_artifact_url }}"
-          output_path="$RUNNER_TEMP/specmatic-enterprise.jar"
-          echo "Downloading Enterprise artifact from:"
-          echo "$url"
-
-          initial_sleep=$(( RANDOM % 31 ))
-          echo "Initial jitter: ${initial_sleep}s"
-          sleep "$initial_sleep"
-
-          echo "Download attempt 1/1"
-          curl --http1.1 -L --fail --continue-at - "$url" -o "$output_path"
-          echo "Enterprise artifact downloaded successfully"
-
-      - name: Upload Specmatic Enterprise jar
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: specmatic-enterprise-jar
-          path: ${{ runner.temp }}/specmatic-enterprise.jar
-          if-no-files-found: error
-          retention-days: 1
-
-      - name: Docker Login for orchestrator snapshot image
-        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
-
-      - name: Prepare snapshot image tarball for orchestrator run
-        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          image_archive="$RUNNER_TEMP/specmatic-enterprise-image.tar"
-          docker pull specmatic/enterprise-snapshot
-          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
-          docker image save specmatic/enterprise-snapshot specmatic/enterprise:latest -o "$image_archive"
-
-      - name: Upload snapshot image tarball
-        if: ${{ inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: specmatic-enterprise-image
-          path: ${{ runner.temp }}/specmatic-enterprise-image.tar
-          if-no-files-found: error
-          retention-days: 1
-
   buildAndTest:
-    needs: [prepare_specmatic_internal_assets]
-    if: ${{ always() && (needs.prepare_specmatic_internal_assets.result == 'success' || needs.prepare_specmatic_internal_assets.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -130,21 +57,32 @@ jobs:
           mkdir -p ~/.specmatic
           echo "${{ secrets.SPECMATIC_LICENSE_KEY }}" > ~/.specmatic/specmatic-license.txt
 
-      - name: Download prepared Specmatic Enterprise jar
-        if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        uses: actions/download-artifact@v5
-        with:
-          name: specmatic-enterprise-jar
-          path: ${{ runner.temp }}/specmatic-jar
+      # Start: internal setup required by Specmatic. Sample project users can ignore this block.
+      - name: Add orchestrator context to summary
+        if: ${{ inputs.orchestrator_run_suffix != '' }}
+        run: |
+          echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
+          echo "Run: ${{ inputs.orchestrator_run_suffix }}" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Place prepared Specmatic Enterprise jar
+      - name: Prepare Specmatic Enterprise jar
         if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
         shell: bash
         run: |
           set -euo pipefail
 
           mkdir -p "$HOME/.specmatic"
-          cp "$RUNNER_TEMP/specmatic-jar/specmatic-enterprise.jar" "$HOME/.specmatic/specmatic-enterprise.jar"
+          url="${{ inputs.enterprise_artifact_url }}"
+          output_path="$HOME/.specmatic/specmatic-enterprise.jar"
+          echo "Downloading Enterprise artifact from:"
+          echo "$url"
+
+          initial_sleep=$(( RANDOM % 31 ))
+          echo "Initial jitter: ${initial_sleep}s"
+          sleep "$initial_sleep"
+
+          echo "Download attempt 1/1"
+          curl --http1.1 -L --fail --continue-at - "$url" -o "$output_path"
+          echo "Enterprise artifact downloaded successfully"
 
       - name: Install prepared Specmatic Enterprise jar into local Maven
         if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
@@ -161,6 +99,20 @@ jobs:
             -Dversion="${ENTERPRISE_VERSION}" \
             -Dpackaging=jar \
             -DgeneratePom=true
+
+      - name: Docker Login for orchestrator snapshot image
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
+
+      - name: Prepare snapshot image for orchestrator run
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker pull specmatic/enterprise-snapshot
+          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+      # End: internal setup required by Specmatic.
 
       - name: Download Specmatic Enterprise Jar
         if: ${{ matrix.needsCliInstall }}
@@ -180,21 +132,6 @@ jobs:
             curl -fsSL https://docs.specmatic.io/install-specmatic-enterprise.sh | bash
             echo "Installed default Enterprise jar"
           fi
-
-      - name: Download prepared snapshot image
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        uses: actions/download-artifact@v5
-        with:
-          name: specmatic-enterprise-image
-          path: ${{ runner.temp }}
-
-      - name: Load prepared snapshot image
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          docker load -i "$RUNNER_TEMP/specmatic-enterprise-image.tar"
 
       - name: Run BFF Contract Test
         shell: bash
@@ -264,59 +201,6 @@ jobs:
         with:
           name: html-report-${{ matrix.name }}
           path: build/reports/specmatic/test/html
-
-  cleanup_specmatic_internal_assets:
-    if: ${{ always() && (inputs.orchestrator_run_suffix != '' || (inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '')) }}
-    needs:
-      - prepare_specmatic_internal_assets
-      - buildAndTest
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Delete prepared enterprise jar artifact
-        if: ${{ needs.prepare_specmatic_internal_assets.result == 'success' && inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            });
-            const target = artifacts.find((artifact) => artifact.name === 'specmatic-enterprise-jar');
-            if (target) {
-              await github.rest.actions.deleteArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: target.id
-              });
-              core.info(`Deleted artifact ${target.name}`);
-            } else {
-              core.info('Artifact specmatic-enterprise-jar not found');
-            }
-
-      - name: Delete prepared enterprise image artifact
-        if: ${{ needs.prepare_specmatic_internal_assets.result == 'success' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            });
-            const target = artifacts.find((artifact) => artifact.name === 'specmatic-enterprise-image');
-            if (target) {
-              await github.rest.actions.deleteArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: target.id
-              });
-              core.info(`Deleted artifact ${target.name}`);
-            } else {
-              core.info('Artifact specmatic-enterprise-image not found');
-            }
 
   docker:
     if: ${{ github.ref == 'refs/heads/main' && inputs.orchestrator_run_suffix == '' }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,6 @@ on:
         description: Specmatic Enterprise version under test
         required: false
         type: string
-      enterprise_docker_image:
-        description: Specmatic Enterprise docker image under test
-        required: false
-        type: string
       enterprise_artifact_url:
         description: Specmatic Enterprise jar/artifact URL under test
         required: false
@@ -79,7 +75,6 @@ jobs:
     env:
       CTRF_REPORT_PATH: './build/reports/specmatic/test/ctrf/*.json'
       ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
-      ENTERPRISE_DOCKER_IMAGE: ${{ inputs.enterprise_docker_image }}
       ENTERPRISE_ARTIFACT_URL: ${{ inputs.enterprise_artifact_url }}
     steps:
       - name: Checkout project
@@ -126,9 +121,18 @@ jobs:
             echo "Installed default Enterprise jar"
           fi
 
-      - name: Docker Login for orchestrated image
-        if: ${{ matrix.name == 'docker' && inputs.enterprise_docker_image != '' && github.ref == 'refs/heads/main' }}
+      - name: Docker Login for orchestrator snapshot run
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
         run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
+
+      - name: Pull and retag snapshot image for orchestrator run
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker pull specmatic/enterprise-snapshot
+          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
 
       - name: Install Specmatic Enterprise Jar into local Maven
         if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       enterprise_artifact_url:
-        description: Deprecated fat-jar artifact URL input; retained for workflow compatibility
+        description: Specmatic Enterprise jar/artifact URL under test
         required: false
         type: string
       orchestrator_run_suffix:
@@ -96,8 +96,9 @@ jobs:
           set -euo pipefail
           mkdir -p ~/.specmatic
 
-          if [ -n "${ENTERPRISE_ARTIFACT_URL}" ] && [ -f ~/.specmatic/specmatic-enterprise.jar ]; then
-            echo "Using Enterprise jar from workflow_dispatch enterprise_artifact_url"
+          if [ -n "${ENTERPRISE_ARTIFACT_URL}" ]; then
+            curl -fsSL "${ENTERPRISE_ARTIFACT_URL}" -o ~/.specmatic/specmatic-enterprise.jar
+            echo "Downloaded Enterprise jar from workflow_dispatch enterprise_artifact_url"
           elif [ -n "${ENTERPRISE_VERSION}" ]; then
             curl -fsSL https://docs.specmatic.io/install-specmatic-enterprise.sh | bash -s -- --version "${ENTERPRISE_VERSION}"
             echo "Installed Enterprise jar for version ${ENTERPRISE_VERSION}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -122,11 +122,11 @@ jobs:
           fi
 
       - name: Docker Login for orchestrator snapshot run
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
         run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
 
       - name: Pull and retag snapshot image for orchestrator run
-        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
+        if: ${{ matrix.name == 'docker' && inputs.orchestrator_run_suffix != '' && inputs.enterprise_artifact_url != '' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,6 +14,10 @@ on:
         description: Specmatic Enterprise version under test
         required: false
         type: string
+      enterprise_docker_image:
+        description: Specmatic Enterprise docker image under test
+        required: false
+        type: string
       enterprise_artifact_url:
         description: Specmatic Enterprise jar/artifact URL under test
         required: false
@@ -75,6 +79,7 @@ jobs:
     env:
       CTRF_REPORT_PATH: './build/reports/specmatic/test/ctrf/*.json'
       ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
+      ENTERPRISE_DOCKER_IMAGE: ${{ inputs.enterprise_docker_image }}
       ENTERPRISE_ARTIFACT_URL: ${{ inputs.enterprise_artifact_url }}
     steps:
       - name: Checkout project
@@ -121,8 +126,8 @@ jobs:
             echo "Installed default Enterprise jar"
           fi
 
-      - name: Docker Login for snapshot image
-        if: ${{ matrix.name == 'docker' && inputs.enterprise_artifact_url != '' && github.ref == 'refs/heads/main' }}
+      - name: Docker Login for orchestrated image
+        if: ${{ matrix.name == 'docker' && inputs.enterprise_docker_image != '' && github.ref == 'refs/heads/main' }}
         run: echo ${{ secrets.SPECMATIC_DOCKER_HUB_TOKEN }} | docker login -u ${{ vars.SPECMATIC_DOCKER_HUB_USERNAME }} --password-stdin
 
       - name: Install Specmatic Enterprise Jar into local Maven

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -114,8 +114,6 @@ jobs:
             needsCliInstall: false
     env:
       CTRF_REPORT_PATH: './build/reports/specmatic/test/ctrf/*.json'
-      ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
-      ENTERPRISE_ARTIFACT_URL: ${{ inputs.enterprise_artifact_url }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v6
@@ -151,6 +149,8 @@ jobs:
       - name: Install prepared Specmatic Enterprise jar into local Maven
         if: ${{ inputs.enterprise_artifact_url != '' && inputs.enterprise_version != '' }}
         shell: bash
+        env:
+          ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
         run: |
           set -euo pipefail
 
@@ -164,6 +164,9 @@ jobs:
 
       - name: Download Specmatic Enterprise Jar
         if: ${{ matrix.needsCliInstall }}
+        env:
+          ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
+          ENTERPRISE_ARTIFACT_URL: ${{ inputs.enterprise_artifact_url }}
         run: |
           set -euo pipefail
           mkdir -p ~/.specmatic
@@ -195,6 +198,8 @@ jobs:
 
       - name: Run BFF Contract Test
         shell: bash
+        env:
+          ENTERPRISE_VERSION: ${{ inputs.enterprise_version }}
         run: |
           set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ gradlew test --tests="com.component.orders.contract.ContractTestsUsingTestContai
 
 ### 3. Using CLI based test execution
 
-Note: Please make sure you download the Specmatic Enterprise jar from [Specmatic's download page](https://docs.specmatic.io/download#specmatic-enterprise).
-
 For **Unix based systems** and **Windows Powershell**:
 ```shell
 ./gradlew test --tests="com.component.orders.contract.ContractTestUsingCLITest"
@@ -76,6 +74,7 @@ For **Unix based systems** and **Windows Powershell**:
 For **Windows Command Prompt**:
 ```shell
 gradlew test --tests="com.component.orders.contract.ContractTestUsingCLITest"
+```
 
 ### 4. Using Docker
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,9 @@ plugins {
     id 'jacoco'
 }
 
-def snapshotRepoUrl = project.findProperty('snapshotRepoUrl')
-
 repositories {
-    mavenLocal()
     mavenCentral()
-
-    if (snapshotRepoUrl) {
-        maven {
-            url = uri(snapshotRepoUrl)
-        }
-    }
+    mavenLocal()
 }
 
 jacocoTestReport {

--- a/gradle/specmatic-snapshots.init.gradle
+++ b/gradle/specmatic-snapshots.init.gradle
@@ -1,0 +1,10 @@
+allprojects {
+    repositories {
+        maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots")
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/component/orders/contract/ContractTestsUsingTestContainer.kt
+++ b/src/test/kotlin/com/component/orders/contract/ContractTestsUsingTestContainer.kt
@@ -20,13 +20,8 @@ class ContractTestsUsingTestContainer {
         fun isNonCIOrLinux(): Boolean =
             System.getenv("CI") != "true" || System.getProperty("os.name").lowercase().contains("linux")
 
-        private fun enterpriseImage(): String =
-            System.getenv("ENTERPRISE_DOCKER_IMAGE")
-                ?.takeIf { it.isNotBlank() }
-                ?: "specmatic/enterprise"
-
         private fun mockContainerWithSetExpectations(): GenericContainer<*> = object : GenericContainer<Nothing>(
-                enterpriseImage()
+                "specmatic/enterprise"
         ) {
             override fun start() {
                 super.start()
@@ -53,7 +48,7 @@ class ContractTestsUsingTestContainer {
                 .withLogConsumer { print(it.utf8String) }
 
         private val testContainer: GenericContainer<*> =
-            GenericContainer(enterpriseImage())
+            GenericContainer("specmatic/enterprise")
                 .withCommand("test")
                 .withFileSystemBind("./src", "/usr/src/app/src", BindMode.READ_ONLY)
                 .withFileSystemBind("./hooks", "/usr/src/app/hooks", BindMode.READ_ONLY)

--- a/src/test/kotlin/com/component/orders/contract/ContractTestsUsingTestContainer.kt
+++ b/src/test/kotlin/com/component/orders/contract/ContractTestsUsingTestContainer.kt
@@ -21,10 +21,9 @@ class ContractTestsUsingTestContainer {
             System.getenv("CI") != "true" || System.getProperty("os.name").lowercase().contains("linux")
 
         private fun enterpriseImage(): String =
-            if(!System.getenv("ENTERPRISE_ARTIFACT_URL").isNullOrEmpty())
-                "specmatic/enterprise-snapshot"
-            else
-                "specmatic/enterprise"
+            System.getenv("ENTERPRISE_DOCKER_IMAGE")
+                ?.takeIf { it.isNotBlank() }
+                ?: "specmatic/enterprise"
 
         private fun mockContainerWithSetExpectations(): GenericContainer<*> = object : GenericContainer<Nothing>(
                 enterpriseImage()


### PR DESCRIPTION
## Summary
- add a workflow_dispatch input for the orchestrated docker image override
- pass the runtime override into the contract-test job environment
- let ContractTestsUsingTestContainer consume the explicit image and fall back to specmatic/enterprise
